### PR TITLE
Store and update DB in repo

### DIFF
--- a/.github/workflows/update-db.yml
+++ b/.github/workflows/update-db.yml
@@ -8,14 +8,23 @@ on:
 jobs:
   nightly:
     name: Scheduled DB Update
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
+      - 
+        name: Check Endpoint Access
+        if: success()
+        run: curl -Lvk ${{ secrets.API_ENDPOINT }}
       -
         name: Checkout
+        if: success()
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - 
         name: Install Go
         uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
       - 
         name: Build Program
         run: CGO_ENABLED=1 go build -o lu-covid-api .
@@ -24,11 +33,10 @@ jobs:
         run: ./lu-covid-api -update-db
       - 
         name: Commit Database Changes
-        uses: github-actions-x/commit@v2.7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          push-branch: main
-          commit-message: "Update database [automated 🚀]"
-          files: database/cases.db
-          name: Automated
-          email: actions@users.noreply.github.com
+        if: success()
+        run: |-
+          git config user.name actions-bot
+          git config user.email actions@users.noreply.github.com
+          git add database/cases.db
+          git commit -m "Update database [automated 🚀]" || exit 0
+          git push

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ To see the statistics, see [here](https://portal.lancaster.ac.uk/intranet/cms/co
 
 This API exists only to allow for easier manipulation of the data.
 
+### ⚠️ Warning
+
+If you can't reach `portal.lancaster.ac.uk`, you can't host the API. This might be because you are using CloudFlare DNS.
+
 ### API
 
 - **Cases Today** [get]

--- a/db/database.go
+++ b/db/database.go
@@ -176,18 +176,3 @@ func UpdateRate(path string, date time.Time, staff uint64, campus uint64, city u
 func dateAdjust(date time.Time) time.Time {
 	return date.Add(time.Hour * 24)
 }
-
-// FillMissedData adds in any missed days worth of rates
-// The site only shows the past 7 days, this began at 9 days...
-func fillMissedData(path string) error {
-	log.Debugln("💬 adding in missed days (left the site prior to this app")
-	first := time.Date(2020, time.Month(10), 1, 0, 0, 0, 0, time.UTC)
-	if err := InsertNewRate(path, first.Format(time.RFC3339), 1, 2, 0); err != nil {
-		return err
-	}
-	second := time.Date(2020, time.Month(10), 2, 0, 0, 0, 0, time.UTC)
-	if err := InsertNewRate(path, second.Format(time.RFC3339), 4, 2, 0); err != nil {
-		return err
-	}
-	return nil
-}


### PR DESCRIPTION
As the university provides a 7 day rolling data set, this will allow any new hosters to provide the complete data set (starting from 01-10-2020). This will be updated automatically at 8pm each day.